### PR TITLE
Added fallback linking to release page

### DIFF
--- a/src/updaterUI/cupdaterdialog.cpp
+++ b/src/updaterUI/cupdaterdialog.cpp
@@ -42,13 +42,19 @@ CUpdaterDialog::~CUpdaterDialog()
 void CUpdaterDialog::applyUpdate()
 {
 #ifdef _WIN32
-	ui->progressBar->setMaximum(100);
-	ui->progressBar->setValue(0);
-	ui->lblPercentage->setVisible(true);
-	ui->lblOperationInProgress->setText("Downloading the update...");
-	ui->stackedWidget->setCurrentIndex(0);
+	if (_latestUpdateUrl.endsWith("exe"))
+	{
+		ui->progressBar->setMaximum(100);
+		ui->progressBar->setValue(0);
+		ui->lblPercentage->setVisible(true);
+		ui->lblOperationInProgress->setText("Downloading the update...");
+		ui->stackedWidget->setCurrentIndex(0);
 
-	_updater.downloadAndInstallUpdate(_latestUpdateUrl);
+		_updater.downloadAndInstallUpdate(_latestUpdateUrl);
+	} else {
+		QDesktopServices::openUrl(QUrl(_latestUpdateUrl));
+		accept();
+	}
 #else
 	QMessageBox msg(
 		QMessageBox::Question,


### PR DESCRIPTION
GitHub dynamically inserts assets under each release, hence they don't show up in the .html. This change provides a fallback that instead opens the release page in browser.